### PR TITLE
fix(stream): исправление маршрутизации L4 для Steal-Oneself поддоменов и замена недействительного SNI swdist.microsoft.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * **Защита Anti-Loop:** При подключении обычного веб-браузера или сканера активного зондирования Xray перенаправляет (*fallback*) запрос на изолированный слушатель **`127.0.0.1:9443`** (`xver: 1`), минуя внешний L4-роутер 443 и полностью исключая бесконечную петлю пересылки пакетов.
 
 ### 2. Сценарий 2: Classic External REALITY (Внешний камуфляж)
-* Использование доверенных внешних доменов (`swdist.microsoft.com`, `www.samsung.com`, `gateway.icloud.com` и др.) в качестве SNI.
+* Использование доверенных внешних доменов (`gateway.icloud.com`, `www.samsung.com`, `gateway.icloud.com` и др.) в качестве SNI.
 * Каждому внешнему пулу назначается независимый локальный порт (`46443`, `47443` и т.д.), исключая коллизии и балансировочные таймауты.
 
 ### 3. Шлюз VLESS xHTTP (Stream-One) + VLESSENC via Native HTTP/2 (Zero-Drop Engine)
@@ -65,10 +65,10 @@ graph TD
 
     NginxStream -->|SNI: Главный домен / Пустой SNI| NginxSock[Unix Socket: /dev/shm/nginx-http.sock]
     NginxStream -->|SNI: Steal-Oneself cdn.yourdomain.online| XrayStealREALITY[Xray REALITY :45443]
-    NginxStream -->|SNI: Внешний SNI swdist.microsoft.com| XrayClassicREALITY[Xray REALITY :46443]
+    NginxStream -->|SNI: Внешний SNI gateway.icloud.com| XrayClassicREALITY[Xray REALITY :46443]
 
     XrayStealREALITY -->|Fallback не-REALITY / xver=1| NginxFallbackHTTP[Nginx HTTP :9443 Anti-Loop]
-    XrayClassicREALITY -->|Fallback не-REALITY / Direct xver=0| ExternalSite[Внешний ресурс swdist.microsoft.com:443]
+    XrayClassicREALITY -->|Fallback не-REALITY / Direct xver=0| ExternalSite[Внешний ресурс gateway.icloud.com:443]
 
     NginxSock --> NginxHTTPCore[Nginx HTTP L7 Engine]
     NginxFallbackHTTP --> NginxHTTPCore
@@ -145,7 +145,7 @@ chmod +x setup_mask.sh
   * Добавить ещё порт Steal-Oneself? `n` (или `y` для настройки доп. портов)
 * **Classic External REALITY:** `y`
   * Локальный порт Xray: `46443`
-  * Внешний SNI: `swdist.microsoft.com`
+  * Внешний SNI: `gateway.icloud.com`
   * Добавить ещё порт Classic? `n`
 * **Дополнительные SSL-домены:** *(Enter для завершения)*
 * **Внутренний порт панели 3X-UI:** `10443`
@@ -218,9 +218,9 @@ ufw deny 10443/tcp && ufw deny 55443/tcp && ufw deny 50443/tcp && ufw deny 9443/
 * **Поток:** Транспорт `tcp` | Accept Proxy Protocol: `1` (Включить) ⚠️
 * **Безопасность:** `reality` | uTLS `chrome`
 * **Flow:** `xtls-rprx-vision`
-* **Цель (Target):** `swdist.microsoft.com:443`
+* **Цель (Target):** `gateway.icloud.com:443`
 * **Proxy Protocol для Dest (xver):** `0` (Выключить) ⚠️
-* **Server Names (SNI):** `swdist.microsoft.com`
+* **Server Names (SNI):** `gateway.icloud.com`
 
 ---
 
@@ -467,9 +467,9 @@ nginx -t && systemctl restart nginx && systemctl restart x-ui
     "realitySettings": {
       "show": false,
       "xver": 0,
-      "dest": "swdist.microsoft.com:443",
+      "dest": "gateway.icloud.com:443",
       "serverNames": [
-        "swdist.microsoft.com"
+        "gateway.icloud.com"
       ],
       "privateKey": "ВАШ_PRIVATE_KEY",
       "shortIds": [

--- a/setup_mask.sh
+++ b/setup_mask.sh
@@ -223,7 +223,7 @@ if [[ "${ENABLE_CLASSIC_INPUT,,}" == "y" ]]; then
         echo -e "${CYAN}  Введите внешние SNI для порта $PORT_VAL (нажмите Enter на пустой строке для завершения):${NC}"
         added_sni_count=0
         while true; do
-            read -rp "    Внешний SNI (например, swdist.microsoft.com): " EXT_SNI
+            read -rp "    Внешний SNI (например, gateway.icloud.com): " EXT_SNI
             if [ -z "$EXT_SNI" ]; then
                 if [ "$added_sni_count" -eq 0 ]; then
                     warn "    Порт $PORT_VAL зарегистрирован для обработки fallback-трафика."
@@ -1401,9 +1401,7 @@ STREAM_MAP_RULES=""
 REALITY_UPSTREAMS=""
 
 for dom in "${ALL_DOMAINS[@]}"; do
-    if [ "$dom" = "$PRIMARY_DOMAIN" ] || [ "$dom" = "www.$PRIMARY_DOMAIN" ]; then
-        STREAM_MAP_RULES+="        ${dom}     nginx_http_backend;"$'\n'
-    elif [ "$STEAL_ENABLED" -eq 1 ] && [ -n "${DOMAIN_TO_PORT[$dom]:-}" ]; then
+    if [ "$STEAL_ENABLED" -eq 1 ] && [ -n "${DOMAIN_TO_PORT[$dom]:-}" ]; then
         port="${DOMAIN_TO_PORT[$dom]}"
         STREAM_MAP_RULES+="        ${dom}     reality_backend_${port};"$'\n'
     else
@@ -1903,7 +1901,7 @@ if [ "$CLASSIC_ENABLED" -eq 1 ]; then
                 p_snis+=("$ext_sni")
             fi
         done
-        [ ${#p_snis[@]} -gt 0 ] || p_snis=("swdist.microsoft.com")
+        [ ${#p_snis[@]} -gt 0 ] || p_snis=("gateway.icloud.com")
         primary_ext="${p_snis[0]}"
 
         REALITY_INBOUNDS_REPORT+="    - Инбаунд для порта ${GREEN}${port}${NC} (SNI: ${CYAN}${p_snis[*]}${NC}):


### PR DESCRIPTION
### Краткое описание изменений (Summary)
Данный Pull Request устраняет две критические ошибки в базовой маршрутизации Nginx Stream и камуфляже Xray REALITY:
1. **Исправлена коллизия L4-маршрутизации** при использовании поддомена `www` в режиме Steal-Oneself REALITY, приводившая к перехвату TLS-трафика веб-сервером Nginx и ошибке клиента `REALITY: received real certificate (potential MITM)`.
2. **Заменен устаревший и несуществующий в DNS дефолтный домен камуфляжа** `swdist.microsoft.com` (возвращает `NXDOMAIN`) на высоконадежный эталонный SNI `gateway.icloud.com` (Apple iCloud).

---

### Подробный разбор проблем и причин (Root Cause Analysis)

#### 1. Коллизия в карте маршрутизации L4 Stream для Steal-Oneself
* **Проблема:** Если при настройке Steal-Oneself администратор указывает поддомен `www.<домен>` (например, `www.domain.com`), то при подключении клиента с этим SNI клиент Xray выдает ошибку безопасности:
  ```text
  transport/internet/reality: REALITY: received real certificate (potential MITM or redirection)
  ```
* **Причина:** В файле `setup_mask.sh` генерация блока `STREAM_MAP_RULES` для `/etc/nginx/stream.d/00-stream.conf` содержала следующую логику:
  ```bash
  for dom in "${ALL_DOMAINS[@]}"; do
      if [ "$dom" = "$PRIMARY_DOMAIN" ] || [ "$dom" = "www.$PRIMARY_DOMAIN" ]; then
          STREAM_MAP_RULES+="        ${dom}     nginx_http_backend;"$'\n'
      elif [ "$STEAL_ENABLED" -eq 1 ] && [ -n "${DOMAIN_TO_PORT[$dom]:-}" ]; then
          port="${DOMAIN_TO_PORT[$dom]}"
          STREAM_MAP_RULES+="        ${dom}     reality_backend_${port};"$''
      ...
  ```
  Условие `[ "$dom" = "www.$PRIMARY_DOMAIN" ]` выполнялось первым, безусловно направляя домен `www` в сокет `nginx_http_backend`. В результате Nginx на сокете терминировал TLS своим сертификатом Let's Encrypt вместо проксирования в Xray.
* **Решение:** Проверка наличия домена в ассоциативном массиве `DOMAIN_TO_PORT` вынесена на первое место. Если домен зарегистрирован для Steal-Oneself, он гарантированно направляется в `reality_backend_${port}`. Все остальные домены (включая основной и www, если они не задействованы в Steal-Oneself) безопасно уходят в `nginx_http_backend`.

#### 2. Недействительный домен Classic REALITY `swdist.microsoft.com`
* **Проблема:** При использовании дефолтного внешнего SNI `swdist.microsoft.com` исходящие подключения Xray REALITY сбрасывались сервером с ошибкой `EOF` / `handshake did not complete successfully`.
* **Причина:** Корпорация Microsoft удалила `swdist.microsoft.com` из глобальной зоны DNS (`NXDOMAIN`). Xray не может разрешить адрес хоста при обращении к целевому серверу для маскировки.
* **Решение:** Дефолтный SNI в коде `setup_mask.sh` и в примерах `README.md` заменен на `gateway.icloud.com` (Apple iCloud):
  - Полноценная поддержка TLS 1.3, ALPN `h2`, эллиптической кривой X25519;
  - Компактная цепочка сертификатов, исключающая переполнение буферов REALITY;
  - Высокая доступность и устойчивость к блокировкам систем DPI.

---

### Точечный дифференциал (Diff)

```diff
--- a/setup_mask.sh
+++ b/setup_mask.sh
@@ -226,1 +226,1 @@
-            read -rp "    Внешний SNI (например, swdist.microsoft.com): " EXT_SNI
+            read -rp "    Внешний SNI (например, gateway.icloud.com): " EXT_SNI
@@ -1403,3 +1403,1 @@
-    if [ "$dom" = "$PRIMARY_DOMAIN" ] || [ "$dom" = "www.$PRIMARY_DOMAIN" ]; then
-        STREAM_MAP_RULES+="        ${dom}     nginx_http_backend;"$'\n'
-    elif [ "$STEAL_ENABLED" -eq 1 ] && [ -n "${DOMAIN_TO_PORT[$dom]:-}" ]; then
+    if [ "$STEAL_ENABLED" -eq 1 ] && [ -n "${DOMAIN_TO_PORT[$dom]:-}" ]; then
@@ -1906,1 +1904,1 @@
-        [ ${#p_snis[@]} -gt 0 ] || p_snis=("swdist.microsoft.com")
+        [ ${#p_snis[@]} -gt 0 ] || p_snis=("gateway.icloud.com")
```
